### PR TITLE
Make the normalizeDateFromString() method static.

### DIFF
--- a/src/RoughDate/RoughDate.php
+++ b/src/RoughDate/RoughDate.php
@@ -101,7 +101,7 @@ final class RoughDate
      *
      * @return string
      */
-    private function normalizeDateFromString($input)
+    private static function normalizeDateFromString($input)
     {
         if (preg_match('/^\d{4}[\-][0]{2}[\-][0]{2}$/', $input) || preg_match('/^\d{4}[\-]\d{2}[\-][0]{2}$/', $input)) {
             return $input;


### PR DESCRIPTION
`normalizeDateFromString()` is called statically but it is not declared static, which results in a strict standards warning when running specs (or using the class):

```
Strict Standards: Non-static method RoughDate\RoughDate::normalizeDateFromString() should not be called statically in /Users/jzalas/Projects/rough-date/src/Ro
ughDate/RoughDate.php on line 40
PHP Strict Standards:  Non-static method RoughDate\RoughDate::normalizeDateFromString() should not be called statically in /Users/jzalas/Projects/rough-date/s
rc/RoughDate/RoughDate.php on line 40
```
